### PR TITLE
Re-usable workflows to test PyPI & Docker releases

### DIFF
--- a/.github/workflows/test_docker_release.yml
+++ b/.github/workflows/test_docker_release.yml
@@ -1,0 +1,42 @@
+# This workflow tests a Docker release by pulling the corresponding image.
+#
+# This workflow requires a `docker-compose.yml` file at the root of the repository, which should
+# take into account the `VERSION` environment variable to pull the relevant image's version.
+
+on:
+  workflow_call:
+    inputs:
+      image_name:
+        required: true
+        type: string
+        description: "Name of the Docker image to test"
+      version:
+        required: true
+        type: string
+        description: "Version of the Docker image to test"
+
+jobs:
+  test-docker-release:
+    name: Test Docker release
+    runs-on: ubuntu-latest
+    timeout-minutes: 60
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+
+      - name: Set up Python 3.9
+        uses: actions/setup-python@v4
+        with:
+          python-version: 3.9
+
+      - name: Login against a Docker registry
+        uses: docker/login-action@v1
+        with:
+          username: ${{ secrets.DOCKER_LOGIN }}
+          password: ${{ secrets.DOCKER_PASSWORD }}
+
+      - name: Pull Docker image
+        env:
+          VERSION: ${{ inputs.version }}
+        run: docker-compose pull ${{ inputs.image_name }}

--- a/.github/workflows/test_pypi_release.yml
+++ b/.github/workflows/test_pypi_release.yml
@@ -1,0 +1,42 @@
+# This workflow tests a PyPI release by installing the corresponding package with `pip` and
+# importing it with Python.
+
+on:
+  workflow_call:
+    inputs:
+      package_name:
+        required: true
+        type: string
+        description: "Name of the PyPI package to test"
+      version:
+        required: true
+        type: string
+        description: "Version of the PyPI package to test"
+
+jobs:
+  test-pypi-release:
+    name: Test PyPI release
+    runs-on: ubuntu-latest
+    timeout-minutes: 60
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+
+      - name: Set up Python 3.9
+        uses: actions/setup-python@v4
+        with:
+          python-version: 3.9
+
+      - name: Set PyPI credentials in ~/.netrc
+        uses: extractions/netrc@v1
+        with:
+          machine: pypi.arkhn.com
+          username: ${{ secrets.PYPI_ARKHN_USERNAME }}
+          password: ${{ secrets.PYPI_ARKHN_PASSWORD }}
+
+      - name: Install package
+        run: python -m pip install --index-url=https://pypi.arkhn.com/simple ${{ inputs.package_name }}==${{ inputs.version }}
+
+      - name: Test package's import
+        run: python -c "import ${{ inputs.package_name }}"


### PR DESCRIPTION
## Description

<!-- Concisely describe what the pull request does. -->
This PR introduces two simple workflows to test the sanity of releases, either as docker image or as a private pypi package. They are mostly adapted & simplified from code in https://github.com/arkhn/ai.

## Technical details

<!-- Add any other information or technical details about the implementation; or delete the section entirely. -->
- The docker workflow simply pull the relevant image with the right version from Docker; it needs a well configured `docker-compose.yml` file; I didn't document this too much, yet, as the approach & configuration can perhaps be improved in the future
- The PyPI workflow simply `pip install` the relevant package with the relevant version, and run an import of the package

## Definition of Done

- [x] I followed the [Arkhn Code Book](https://www.notion.so/arkhn/Arkhn-Code-Book-23ac18a8af7343d0a3f61f1c9ef7400c) (I swear!).
- [ ] I have written tests for the code I added or updated.
- [ ] I have updated the documentation according to my changes.
- [ ] I have updated the deployment configuration if needed.
