### PR TITLE
Add workflow to auto-assign incident issues to the Incident project

### DIFF
--- a/.github/workflows/incident_report.yml
+++ b/.github/workflows/incident_report.yml
@@ -1,0 +1,19 @@
+# This workflow assigns to every issue (re)opened or labeled with label type/incident the Incident Report project.
+
+name: Project Incident assignment
+
+on:
+  issues:
+    types:
+      - opened
+      - reopened
+      - labeled
+
+jobs:
+  incident-report:
+    if: ${{ github.event.label.name == 'type/incident' }}
+    name: Project assignment (Incident Report)
+    uses: arkhn/.github/.github/workflows/project.yml@96eb3f490c2bedc184eaa0f9684282b7e8214db3
+    with:
+      project_number: 24 # Incident Report project
+    secrets: inherit


### PR DESCRIPTION
## Fixes

<!-- If PR doesn't fully resolve the issue, replace 'Fixes' below with 'Related to'. -->
<!-- If there is no issue being resolved, open one before creating this pull request. -->

Fixes #8

## Description

<!-- Concisely describe what the pull request does. -->
Finally I've put the filter on the label directly on the call to reusable workflow
I've also added a trigger at labelling events.

## Definition of Done

- [x] I followed the [Arkhn Code Book](https://www.notion.so/arkhn/Arkhn-Code-Book-23ac18a8af7343d0a3f61f1c9ef7400c) (I swear!).
- [ ] I have written tests for the code I added or updated.
- [ ] I have updated the documentation according to my changes.
- [ ] I have updated the deployment configuration if needed.
